### PR TITLE
Remove inline reducers

### DIFF
--- a/packages/core/src/hooks/index.tsx
+++ b/packages/core/src/hooks/index.tsx
@@ -1,6 +1,6 @@
 export * from "./useAccessibilityProps";
-export * from "./useAugmentedReducer";
 export * from "./useCallbackRef";
+export * from "./useControlledReducer";
 export * from "./useEnsuredId";
 export * from "./useMenuPlacement";
 export * from "./usePrevious";

--- a/packages/core/src/hooks/useAugmentedReducer.tsx
+++ b/packages/core/src/hooks/useAugmentedReducer.tsx
@@ -7,7 +7,6 @@ import {
   useReducer,
 } from "react";
 
-import { usePrevious } from "./usePrevious";
 import { mergeNonUndefinedProperties } from "../utils";
 
 // https://stackoverflow.com/a/52323412
@@ -33,8 +32,8 @@ export const useAugmentedReducer = <
   props: Props = {} as Props,
   onStateChange?: (state: State, action: Action, prevState: State) => void,
 ): [State, Dispatch<Action>] => {
+  const prevStateRef = useRef(mergeNonUndefinedProperties(initialState, props));
   const propsRef = useRef(props);
-  const previousPropsRef = usePrevious(props);
   const onStateChangeRef = useRef(onStateChange);
 
   useEffect(() => {
@@ -42,47 +41,38 @@ export const useAugmentedReducer = <
     onStateChangeRef.current = onStateChange;
   }, [props, onStateChange]);
 
-  const { current: reduce } = useRef<Reducer<State, Action>>(
-    (prevState, action) => {
-      const { current: props } = propsRef;
-      const { current: previousProps } = previousPropsRef;
-      const { current: onStateChange } = onStateChangeRef;
+  const { current: reduce } = useRef<Reducer<State, Action>>((_, action) => {
+    const { current: props } = propsRef;
+    const { current: onStateChange } = onStateChangeRef;
 
-      // Only merge props on top if they've changed since the last dispatch,
-      // otherwise no-op actions will trigger a render.
-      let prevStateWithProps = prevState;
-      if (props !== previousProps) {
-        prevStateWithProps = mergeNonUndefinedProperties(prevState, props);
+    const prevState = prevStateRef.current;
+
+    let nextState = reducer(prevState, action);
+    if (nextState !== prevState) {
+      // Only call this on state changes.
+      onStateChange?.(nextState, action, prevState);
+
+      // We need to merge props on top after the reducer is done in case it
+      // overrode any of them, but we should only do this if the state
+      // actually changed, otherwise no-op actions will trigger a render.
+      nextState = mergeNonUndefinedProperties(nextState, props);
+      if (shallowCompare(nextState, prevState)) {
+        nextState = prevState;
       }
+    }
 
-      let nextState = reducer(prevStateWithProps, action);
+    prevStateRef.current = nextState;
+    return nextState;
+  });
 
-      if (nextState !== prevStateWithProps) {
-        // Only call this on state changes.
-        onStateChange?.(nextState, action, prevStateWithProps);
-
-        // We need to merge props on top after the reducer is done in case it
-        // overrode any of them, but we should only do this if the state
-        // actually changed, otherwise no-op actions will trigger a render.
-        nextState = mergeNonUndefinedProperties(nextState, props);
-        if (shallowCompare(nextState, prevState)) {
-          return prevState;
-        }
-      }
-
-      return nextState;
-    },
-  );
-
-  const [innerState, dispatch] = useReducer(
-    reduce,
-    mergeNonUndefinedProperties(initialState, props),
-  );
+  const [innerState, dispatch] = useReducer(reduce, prevStateRef.current);
 
   // Redundant props merge so a render will be triggered after props change, even
   // without a corresponding action
   const state = useMemo(() => {
-    return mergeNonUndefinedProperties(innerState, props);
+    const mergedState = mergeNonUndefinedProperties(innerState, props);
+    prevStateRef.current = mergedState;
+    return mergedState;
   }, [innerState, props]);
 
   return [state, dispatch];

--- a/packages/core/src/hooks/useAugmentedReducer.tsx
+++ b/packages/core/src/hooks/useAugmentedReducer.tsx
@@ -1,5 +1,13 @@
-import { Reducer, Dispatch, useEffect, useRef, useReducer } from "react";
+import {
+  Reducer,
+  Dispatch,
+  useEffect,
+  useRef,
+  useMemo,
+  useReducer,
+} from "react";
 
+import { usePrevious } from "./usePrevious";
 import { mergeNonUndefinedProperties } from "../utils";
 
 // https://stackoverflow.com/a/52323412
@@ -15,117 +23,67 @@ const shallowCompare = <Obj1 extends object, Obj2 extends object>(
         (obj2[key as keyof Obj2] as unknown),
   );
 
-export type AugmentedInitAction = { type: "init" };
-const isInitAction = (action: {
-  type: string;
-}): action is AugmentedInitAction => action.type === "init";
-
-export type PropsUpdateAction<Props> = { type: "updateProps"; props: Props };
-const isPropsUpdateAction = <Props extends unknown>(action: {
-  type: string;
-}): action is PropsUpdateAction<Props> => action.type === "updateProps";
-
-export type AugmentedReducerCustom<State, Action, Props> = (
-  state: State,
-  action: Action | PropsUpdateAction<Props> | AugmentedInitAction,
-  reducer: Reducer<
-    State,
-    Action | PropsUpdateAction<Props> | AugmentedInitAction
-  >,
-) => State;
-
-export type AugmentedReducerChangeHandler<State, Action, Props> = (
-  state: State,
-  action: Action | PropsUpdateAction<Props> | AugmentedInitAction,
-  prevState: State,
-) => void;
-
 export const useAugmentedReducer = <
-  State extends {},
-  Action extends { type: string },
+  State extends object,
+  Action,
   Props = Partial<State>
 >(
   reducer: Reducer<State, Action>,
   initialState: State,
   props: Props = {} as Props,
-  customReducer?: AugmentedReducerCustom<State, Action, Props>,
-  onStateChange?: AugmentedReducerChangeHandler<State, Action, Props>,
-): [State, Dispatch<Action | PropsUpdateAction<Props>>] => {
+  onStateChange?: (state: State, action: Action, prevState: State) => void,
+): [State, Dispatch<Action>] => {
   const propsRef = useRef(props);
-  const customReducerRef = useRef(customReducer);
+  const previousPropsRef = usePrevious(props);
   const onStateChangeRef = useRef(onStateChange);
-
-  // Wrap the given reducer with handlers for the "updateProps" and "init"
-  // actions.
-  const { current: propsUpdateReducer } = useRef<
-    Reducer<State, Action | PropsUpdateAction<Props> | AugmentedInitAction>
-  >((prevState, action) => {
-    if (isPropsUpdateAction(action)) {
-      return mergeNonUndefinedProperties(prevState, action.props);
-    }
-
-    if (isInitAction(action)) {
-      return prevState;
-    }
-
-    return reducer(prevState, action);
-  });
-
-  const { current: reduce } = useRef<
-    Reducer<State, Action | PropsUpdateAction<Props> | AugmentedInitAction>
-  >((prevState, action) => {
-    const { current: props } = propsRef;
-    const { current: customReducer } = customReducerRef;
-    const { current: onStateChange } = onStateChangeRef;
-
-    let nextState: State;
-
-    if (customReducer) {
-      nextState = customReducer(prevState, action, propsUpdateReducer);
-    } else {
-      nextState = propsUpdateReducer(prevState, action);
-    }
-
-    if (nextState !== prevState) {
-      // Only call this on state changes.
-      onStateChange?.(nextState, action, prevState);
-
-      // We need to merge props on top after the reducer is done in case it
-      // overrode any of them, but we should only do this if the state
-      // actually changed, otherwise no-op actions will trigger a render.
-      nextState = mergeNonUndefinedProperties(nextState, props);
-      if (shallowCompare(nextState, prevState)) {
-        return prevState;
-      }
-    }
-
-    return nextState;
-  });
-
-  let mergedInitialState = mergeNonUndefinedProperties(initialState, props);
-
-  const hasInitializedRef = useRef(false);
-  if (!hasInitializedRef.current) {
-    customReducer &&
-      (mergedInitialState = customReducer(
-        mergedInitialState,
-        { type: "init" },
-        propsUpdateReducer,
-      ));
-    hasInitializedRef.current = true;
-  }
-
-  const [state, dispatch] = useReducer(reduce, mergedInitialState);
 
   useEffect(() => {
     propsRef.current = props;
-    dispatch({ type: "updateProps", props });
-  }, [props]);
-
-  useEffect(() => {
-    customReducerRef.current = customReducer;
     onStateChangeRef.current = onStateChange;
-  }, [customReducer, onStateChange]);
+  }, [props, onStateChange]);
+
+  const { current: reduce } = useRef<Reducer<State, Action>>(
+    (prevState, action) => {
+      const { current: props } = propsRef;
+      const { current: previousProps } = previousPropsRef;
+      const { current: onStateChange } = onStateChangeRef;
+
+      // Only merge props on top if they've changed since the last dispatch,
+      // otherwise no-op actions will trigger a render.
+      let prevStateWithProps = prevState;
+      if (props !== previousProps) {
+        prevStateWithProps = mergeNonUndefinedProperties(prevState, props);
+      }
+
+      let nextState = reducer(prevStateWithProps, action);
+
+      if (nextState !== prevStateWithProps) {
+        // Only call this on state changes.
+        onStateChange?.(nextState, action, prevStateWithProps);
+
+        // We need to merge props on top after the reducer is done in case it
+        // overrode any of them, but we should only do this if the state
+        // actually changed, otherwise no-op actions will trigger a render.
+        nextState = mergeNonUndefinedProperties(nextState, props);
+        if (shallowCompare(nextState, prevState)) {
+          return prevState;
+        }
+      }
+
+      return nextState;
+    },
+  );
+
+  const [innerState, dispatch] = useReducer(
+    reduce,
+    mergeNonUndefinedProperties(initialState, props),
+  );
+
+  // Redundant props merge so a render will be triggered after props change, even
+  // without a corresponding action
+  const state = useMemo(() => {
+    return mergeNonUndefinedProperties(innerState, props);
+  }, [innerState, props]);
 
   return [state, dispatch];
 };

--- a/packages/core/src/hooks/useAugmentedReducer.tsx
+++ b/packages/core/src/hooks/useAugmentedReducer.tsx
@@ -25,11 +25,11 @@ const shallowCompare = <Obj1 extends object, Obj2 extends object>(
 export const useAugmentedReducer = <
   State extends object,
   Action,
-  Props = Partial<State>
+  InitialState extends State = State
 >(
   reducer: Reducer<State, Action>,
-  initialState: State,
-  props: Props = {} as Props,
+  initialState: InitialState,
+  props: Partial<State> = {},
   onStateChange?: (state: State, action: Action, prevState: State) => void,
 ): [State, Dispatch<Action>] => {
   const prevStateRef = useRef(mergeNonUndefinedProperties(initialState, props));

--- a/packages/core/src/hooks/useControlledReducer.tsx
+++ b/packages/core/src/hooks/useControlledReducer.tsx
@@ -22,7 +22,7 @@ const shallowCompare = <Obj1 extends object, Obj2 extends object>(
         (obj2[key as keyof Obj2] as unknown),
   );
 
-export const useAugmentedReducer = <
+export const useControlledReducer = <
   State extends object,
   Action,
   InitialState extends State = State

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "@emotion/react";
 import range from "lodash-es/range";
 import {
   useCallbackRef,
-  useAugmentedReducer,
+  useControlledReducer,
   createKeyDownHandler,
   simpleMemo,
   selectReducer,
@@ -341,7 +341,7 @@ export const DatePicker: React.FC<{ id?: string; "aria-label"?: string }> = ({
   id: providedId,
   ...rest
 }) => {
-  const [state, dispatch] = useAugmentedReducer(reducer, {
+  const [state, dispatch] = useControlledReducer(reducer, {
     isMenuOpen: false,
     inputValue: "",
     focusedIndex: 0,

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, Reducer, useMemo } from "react";
 import {
-  useAugmentedReducer,
+  useControlledReducer,
   useCallbackRef,
   createKeyDownHandler,
   selectReducer,
@@ -172,7 +172,7 @@ const MenuInner = React.forwardRef<
 });
 
 export const Menu: React.FC<{ options: MenuOptionType[] }> = ({ options }) => {
-  const [state, dispatch] = useAugmentedReducer(
+  const [state, dispatch] = useControlledReducer(
     reducer,
     {
       value: null,

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -1,7 +1,7 @@
 import React, { Reducer, useCallback, useMemo, useRef } from "react";
 
 import {
-  useAugmentedReducer,
+  useControlledReducer,
   useCallbackRef,
   useScrollCaptor,
   useScrollToFocused,
@@ -76,7 +76,7 @@ export const MultiSelect = <T extends { label: string; value: string }>({
     },
   );
 
-  const [state, dispatch] = useAugmentedReducer(
+  const [state, dispatch] = useControlledReducer(
     reducer,
     {
       isMenuOpen: false,

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -10,8 +10,6 @@ import {
   SelectState,
   SelectAction,
   AccessibilityPropsProvider,
-  AugmentedReducerCustom,
-  AugmentedReducerChangeHandler,
 } from "@natural-selection/core";
 
 import { Menu, Option, Container, Control, Placeholder } from "./components";
@@ -23,16 +21,11 @@ type MultiSelectProps<T> = {
   options: T[];
   "aria-label"?: string;
   value?: T[];
-  customReducer?: AugmentedReducerCustom<
-    State<T>,
-    SelectAction<T>,
-    Partial<Pick<MultiSelectProps<T>, "value" | "options">>
-  >;
-  onStateChange?: AugmentedReducerChangeHandler<
-    State<T>,
-    SelectAction<T>,
-    Partial<Pick<MultiSelectProps<T>, "value" | "options">>
-  >;
+  onStateChange?: (
+    state: State<T>,
+    action: SelectAction<T>,
+    prevState: State<T>,
+  ) => void;
 };
 
 type State<T> = SelectState & {
@@ -44,7 +37,7 @@ export const MultiSelect = <T extends { label: string; value: string }>({
   id,
   options,
   value,
-  customReducer,
+  onStateChange,
   ...rest
 }: MultiSelectProps<T>): React.ReactElement => {
   const { current: reducer } = useRef<Reducer<State<T>, SelectAction<T>>>(
@@ -93,7 +86,7 @@ export const MultiSelect = <T extends { label: string; value: string }>({
       options: [],
     },
     useMemo(() => ({ options, value }), [options, value]),
-    customReducer,
+    onStateChange,
   );
 
   const menuRef = useCallbackRef<HTMLDivElement>();

--- a/src/SingleSelect.tsx
+++ b/src/SingleSelect.tsx
@@ -10,34 +10,27 @@ import {
   SelectState,
   SelectAction,
   AccessibilityPropsProvider,
-  AugmentedReducerCustom,
-  AugmentedReducerChangeHandler,
 } from "@natural-selection/core";
 
 import { Menu, Option, Container, Control, Placeholder } from "./components";
 import { useMenuPlacementStyles } from "./hooks";
 import { filteredOptionsSelector, focusedOptionSelector } from "./selectors";
 
+type State<T> = SelectState & {
+  options: T[];
+  value: T | null;
+};
+
 type SingleSelectProps<T> = {
   id?: string;
   "aria-label"?: string;
   options: T[];
   value?: T | null;
-  customReducer?: AugmentedReducerCustom<
-    State<T>,
-    SelectAction<T>,
-    Partial<Pick<SingleSelectProps<T>, "value" | "options">>
-  >;
-  onStateChange?: AugmentedReducerChangeHandler<
-    State<T>,
-    SelectAction<T>,
-    Partial<Pick<SingleSelectProps<T>, "value" | "options">>
-  >;
-};
-
-type State<T> = SelectState & {
-  options: T[];
-  value: T | null;
+  onStateChange?: (
+    state: State<T>,
+    action: SelectAction<T>,
+    prevState: State<T>,
+  ) => void;
 };
 
 const reducer = <OptionType extends { label: string }>(
@@ -73,11 +66,10 @@ export const SingleSelect = <
   id,
   options,
   value,
-  customReducer,
   onStateChange,
   ...rest
 }: SingleSelectProps<T>): React.ReactElement => {
-  const [state, dispatch] = useAugmentedReducer(
+  const [state, dispatch] = useAugmentedReducer<State<T>, SelectAction<T>>(
     reducer,
     {
       isMenuOpen: false,
@@ -87,7 +79,6 @@ export const SingleSelect = <
       options: [],
     },
     useMemo(() => ({ value, options }), [value, options]),
-    customReducer,
     onStateChange,
   );
 

--- a/src/SingleSelect.tsx
+++ b/src/SingleSelect.tsx
@@ -69,7 +69,7 @@ export const SingleSelect = <
   onStateChange,
   ...rest
 }: SingleSelectProps<T>): React.ReactElement => {
-  const [state, dispatch] = useAugmentedReducer<State<T>, SelectAction<T>>(
+  const [state, dispatch] = useAugmentedReducer(
     reducer,
     {
       isMenuOpen: false,

--- a/src/SingleSelect.tsx
+++ b/src/SingleSelect.tsx
@@ -4,7 +4,7 @@ import {
   useCallbackRef,
   useScrollCaptor,
   useScrollToFocused,
-  useAugmentedReducer,
+  useControlledReducer,
   createKeyDownHandler,
   selectReducer,
   SelectState,
@@ -69,7 +69,7 @@ export const SingleSelect = <
   onStateChange,
   ...rest
 }: SingleSelectProps<T>): React.ReactElement => {
-  const [state, dispatch] = useAugmentedReducer(
+  const [state, dispatch] = useControlledReducer(
     reducer,
     {
       isMenuOpen: false,


### PR DESCRIPTION
Inline reducers was starting to feel like a bad idea–prop interfaces clean up considerably without them and there's fewer edges cases. Better to just write a new reducer if that functionality is needed.