### PR TITLE
Call onStateChange after state updates

### DIFF
--- a/packages/core/src/hooks/useControlledReducer.tsx
+++ b/packages/core/src/hooks/useControlledReducer.tsx
@@ -27,26 +27,42 @@ export const useControlledReducer = <
   props: Partial<State> = defaultProps,
   onStateChange?: (state: State, action: Action, prevState: State) => void,
 ): [State, Dispatch<Action>] => {
-  const propsRef = useRef(props);
-  const onStateChangeRef = useRef(onStateChange);
-
-  useEffect(() => {
-    propsRef.current = props;
-    onStateChangeRef.current = onStateChange;
-  }, [props, onStateChange]);
-
   const [state, setState] = useState<State>(
     mergeNonUndefinedProperties(initialState, props),
   );
 
+  // Mirror props/state into refs so we can reference them in dependencies of
+  // "dispatch" without requiring re-renders.
+  // The idea is to make "dispatch" a static reference just like vanilla React.
+  const stateRef = useRef(state);
+  const propsRef = useRef(props);
+  const onStateChangeRef = useRef(onStateChange);
+
+  // Keep these refs in sync with the corresponding state/props
+  useEffect(() => {
+    stateRef.current = state;
+    propsRef.current = props;
+    onStateChangeRef.current = onStateChange;
+  }, [state, props, onStateChange]);
+
+  // Bind arguments to onStateChange so it can be called after state updates
+  // without having to bring those arguments into a higher scope.
+  //
+  // After calling, the "current" property should be set to undefined so it's
+  // not called again.
+  const afterStateChangeCallbackRef = useRef<() => void | undefined>();
+
   const reducerRef = useRef<Reducer<State, Action>>((prevState, action) => {
     const { current: props } = propsRef;
-    const { current: onStateChange } = onStateChangeRef;
 
     let nextState = reducer(prevState, action);
     if (nextState !== prevState) {
-      // Only call this on state changes.
-      onStateChange?.(nextState, action, prevState);
+      // need to declare a new variable here since nextState may be reassigned
+      // TODO remove the "let" statement so this isn't an issue
+      const unmergedNextState = nextState;
+
+      afterStateChangeCallbackRef.current = () =>
+        onStateChangeRef.current?.(unmergedNextState, action, prevState);
 
       // We need to merge props on top after the reducer is done in case it
       // overrode any of them, but we should only do this if the state
@@ -60,12 +76,28 @@ export const useControlledReducer = <
     return nextState;
   });
 
+  // Merge prop changes into state.
   useEffect(() => {
     setState(state => mergeNonUndefinedProperties(state, props));
   }, [props]);
 
+  // Call onStateChange after state updates.
+  useEffect(() => {
+    afterStateChangeCallbackRef.current?.();
+    afterStateChangeCallbackRef.current = undefined;
+  }, [state]);
+
   const dispatch = useRef<Dispatch<Action>>(action => {
-    setState(state => reducerRef.current(state, action));
+    const prevState = stateRef.current;
+    const nextState = reducerRef.current(prevState, action);
+    setState(nextState);
+
+    // If state is unchanged, we need to call onStateChange manually as the
+    // effect above won't be triggered.
+    if (prevState === nextState) {
+      afterStateChangeCallbackRef.current?.();
+      afterStateChangeCallbackRef.current = undefined;
+    }
   }).current;
 
   return [state, dispatch];


### PR DESCRIPTION
Previously, `onStateChange` was called before `useControlledReducer`'s internal state was updated. This may cause issues when providing an `onStateChange` handler that causes the component to be unmounted.

This PR updates `useControlledReducer` so that `onStateChange` will only be called after state updates are committed.