### PR TITLE
Option component accessibility tweaks

### DIFF
--- a/packages/core/src/components.tsx
+++ b/packages/core/src/components.tsx
@@ -119,8 +119,6 @@ export const Option = simpleMemo(function Option<T>({
   option,
   dispatch,
   innerRef,
-  isDisabled,
-  isFocused,
   ...rest
 }: OptionProps<T>) {
   const { getOptionProps: getAccessibilityProps } = useAccessibilityProps();
@@ -144,11 +142,11 @@ export const Option = simpleMemo(function Option<T>({
   return (
     <Component
       {...rest}
-      {...getAccessibilityProps(option, { isFocused })}
+      {...getAccessibilityProps(option, { isFocused: rest.isFocused })}
       ref={innerRef}
       tabIndex={-1}
       onMouseDown={preventDefault}
-      {...(!isDisabled && {
+      {...(!rest.isDisabled && {
         onClick: onClick,
         onMouseMove: onHover,
         onMouseOver: onHover,
@@ -223,13 +221,14 @@ export const AccessibilityPropsProvider = <OptionType extends unknown>({
           }),
         },
         menuProps: { id: menuId, role },
-        getOptionProps: (option, { isFocused }) => {
+        getOptionProps: (option, { isFocused, isDisabled }) => {
           const index = options.indexOf(option as OptionType);
           const label = getOptionLabel(option as OptionType);
 
           return {
             role: "option",
             "aria-selected": isFocused,
+            "aria-disabled": isDisabled,
             ...(index > -1 && {
               id: getOptionId(id, option as OptionType, options),
             }),

--- a/packages/core/src/context.tsx
+++ b/packages/core/src/context.tsx
@@ -22,6 +22,7 @@ export type AccessibilityContextType = {
     option: OptionType,
     state: {
       isFocused?: boolean;
+      isDisabled?: boolean;
     },
   ) => { "aria-selected"?: boolean; role?: "option"; id?: string };
 };


### PR DESCRIPTION
- add `aria-disabled` to option props given by `AccessibilityPropsProvider`
- pass `isFocused`, `isDisabled` through `Option` so that they can be consumed through the `as` prop