### PR TITLE
useControlledReducer tweaks

### DIFF
--- a/packages/core/src/hooks/useControlledReducer.tsx
+++ b/packages/core/src/hooks/useControlledReducer.tsx
@@ -76,7 +76,14 @@ export const useControlledReducer = <
   });
 
   // Merge prop changes into state.
+  const skipPropMergeRef = useRef(true);
   useEffect(() => {
+    if (skipPropMergeRef.current) {
+      // No need to do this on mount
+      skipPropMergeRef.current = false;
+      return;
+    }
+
     setState(state => {
       const nextState = mergeNonUndefinedProperties(state, props);
       stateRef.current = nextState;


### PR DESCRIPTION
- avoid unnecessary `setState` call on mount
- make the reducer wrapper easier to read

~~This has got me thinking, though, that a shallow comparison should be done every time the props merge effect is triggered.~~ `useMemo` on the props effectively does this