### PR TITLE
useScrollToFocused refactor

### DIFF
--- a/cypress/integration/natural-selection/date_picker.spec.tsx
+++ b/cypress/integration/natural-selection/date_picker.spec.tsx
@@ -24,7 +24,7 @@ it("picks a day and closes on click", () => {
 it("picks a day and closes on space", () => {
   // TODO fix this force, Cypress thinks the placeholder is covering it
   cy.queryByLabelText("Date picker example").click({ force: true });
-  cy.queryByText("8").trigger("mouseover");
+  cy.queryByText("8").trigger("mousemove");
   cy.queryByLabelText("Date picker example").type(" ", { force: true });
   cy.queryByText("02/08/2020").should("exist");
   cy.queryByText("February").should("not.exist");

--- a/cypress/integration/natural-selection/multi_select.spec.tsx
+++ b/cypress/integration/natural-selection/multi_select.spec.tsx
@@ -122,3 +122,37 @@ it("clears input on close", () => {
   cy.wrap(document.body).click({ force: true });
   cy.queryByText("Optio").should("not.exist");
 });
+
+it("closes the menu on escape press", () => {
+  cy.queryByText("Select multiple options").click();
+  cy.queryByText("Option 1").should("exist");
+  cy.queryByLabelText("Multi select example").type("{esc}", {
+    force: true,
+  });
+  cy.queryByText("Option 1").should("not.exist");
+});
+
+it("clears the selected value on backspace", () => {
+  cy.queryByText("Select multiple options").click();
+  cy.queryByText("Option 2").click();
+  // TODO fix this force, Cypress thinks the placeholder is covering it
+  cy.queryByLabelText("Multi select example").type("{esc}", {
+    force: true,
+  });
+  cy.queryByText("Option 1").should("not.exist");
+  cy.queryByLabelText("Multi select example").type("{backspace}", {
+    force: true,
+  });
+  cy.queryByText("Option 2").should("not.exist");
+});
+
+it("doesn't interrupt backspace when text is entered", () => {
+  cy.queryByText("Select multiple options").click();
+  cy.queryByText("Option 2").click();
+  // TODO fix this force, Cypress thinks the placeholder is covering it
+  cy.queryByLabelText("Multi select example").type("ABC{backspace}", {
+    force: true,
+  });
+  cy.queryByText("AB").should("exist");
+  cy.queryByText(/Option 2/).should("exist");
+});

--- a/cypress/integration/natural-selection/multi_select.spec.tsx
+++ b/cypress/integration/natural-selection/multi_select.spec.tsx
@@ -23,7 +23,7 @@ it("focuses options on mouse hover", () => {
     "rgb(0, 0, 255)",
   );
 
-  cy.queryByText("Option 2").trigger("mouseover");
+  cy.queryByText("Option 2").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",
@@ -33,7 +33,7 @@ it("focuses options on mouse hover", () => {
   // DOM focus unchanged
   cy.queryByLabelText("Multi select example").should("be.focused");
 
-  cy.queryByText("Option 1").trigger("mouseover");
+  cy.queryByText("Option 1").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",
@@ -67,7 +67,7 @@ it("focuses options on arrow key press", () => {
   cy.queryByLabelText("Multi select example").type("{uparrow}", {
     force: true,
   });
-  cy.queryByText("Option 1").trigger("mouseover");
+  cy.queryByText("Option 1").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",

--- a/cypress/integration/natural-selection/single_select.spec.tsx
+++ b/cypress/integration/natural-selection/single_select.spec.tsx
@@ -129,3 +129,32 @@ it("clears input on close", () => {
   cy.wrap(document.body).click({ force: true });
   cy.queryByText("Optio").should("not.exist");
 });
+
+it("closes the menu on escape press", () => {
+  cy.queryByText("Pick an option").click();
+  cy.queryByText("Option 1").should("exist");
+  cy.queryByLabelText("Single select example").type("{esc}", {
+    force: true,
+  });
+  cy.queryByText("Option 1").should("not.exist");
+});
+
+it("clears the selected value on backspace", () => {
+  cy.queryByText("Pick an option").click();
+  cy.queryByText("Option 2").click();
+  // TODO fix this force, Cypress thinks the placeholder is covering it
+  cy.queryByLabelText("Single select example").type("{backspace}", {
+    force: true,
+  });
+  cy.queryByText("Option 2").should("not.exist");
+});
+
+it("doesn't interrupt backspace when text is entered", () => {
+  cy.queryByText("Pick an option").click();
+  cy.queryByText("Option 2").click();
+  // TODO fix this force, Cypress thinks the placeholder is covering it
+  cy.queryByLabelText("Single select example").type("ABC{backspace}", {
+    force: true,
+  });
+  cy.queryByText("AB").should("exist");
+});

--- a/cypress/integration/natural-selection/single_select.spec.tsx
+++ b/cypress/integration/natural-selection/single_select.spec.tsx
@@ -23,7 +23,7 @@ it("focuses options on mouse hover", () => {
     "rgb(0, 0, 255)",
   );
 
-  cy.queryByText("Option 2").trigger("mouseover");
+  cy.queryByText("Option 2").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",
@@ -33,7 +33,7 @@ it("focuses options on mouse hover", () => {
   // DOM focus unchanged
   cy.queryByLabelText("Single select example").should("be.focused");
 
-  cy.queryByText("Option 1").trigger("mouseover");
+  cy.queryByText("Option 1").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",
@@ -67,7 +67,7 @@ it("focuses options on arrow key press", () => {
   cy.queryByLabelText("Single select example").type("{uparrow}", {
     force: true,
   });
-  cy.queryByText("Option 1").trigger("mouseover");
+  cy.queryByText("Option 1").trigger("mousemove");
   cy.queryByText("Option 2").should(
     "have.css",
     "backgroundColor",

--- a/packages/core/src/actions.tsx
+++ b/packages/core/src/actions.tsx
@@ -14,24 +14,18 @@ export const createKeyDownHandler = (
     inputValue: string;
     isMenuOpen: boolean;
   },
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  scrollToFocused: () => void = () => {},
 ) => (event: React.KeyboardEvent): void => {
   switch (event.key) {
     case "ArrowDown":
-      scrollToFocused();
       dispatch({
         type: "relativeFocus",
         direction: 1,
-        source: "keyboard",
       });
       break;
     case "ArrowUp":
-      scrollToFocused();
       dispatch({
         type: "relativeFocus",
         direction: -1,
-        source: "keyboard",
       });
       break;
     case " ":

--- a/packages/core/src/components.tsx
+++ b/packages/core/src/components.tsx
@@ -136,10 +136,10 @@ export const Option = simpleMemo(function Option<T>({
     [dispatch, option],
   );
 
-  const onHover = useCallback(
+  const onMouseMove = useCallback(
     (event: React.SyntheticEvent) => {
       event.stopPropagation();
-      dispatch({ type: "focusOption", option, source: "mouse" });
+      dispatch({ type: "focusOption", option });
     },
     [dispatch, option],
   );
@@ -152,9 +152,8 @@ export const Option = simpleMemo(function Option<T>({
       tabIndex={-1}
       onMouseDown={preventDefault}
       {...(!isDisabled && {
-        onClick: onClick,
-        onMouseMove: onHover,
-        onMouseOver: onHover,
+        onClick,
+        onMouseMove,
       })}
     />
   );

--- a/packages/core/src/reducers.tsx
+++ b/packages/core/src/reducers.tsx
@@ -12,13 +12,11 @@ export type SelectOptionAction<OptionType> = {
 export type FocusOptionAction<OptionType> = {
   type: "focusOption";
   option: OptionType;
-  source?: "keyboard" | "mouse";
 };
 
 export type RelativeFocusAction = {
   type: "relativeFocus";
   direction: number;
-  source?: "keyboard" | "mouse";
 };
 
 export type SelectAction<OptionType> =

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -91,8 +91,8 @@ export const MultiSelect = <T extends { label: string; value: string }>({
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
   const placementStyles = useMenuPlacementStyles(menuRef);
   useScrollCaptor(menuRef);
-  const scrollToFocused = useScrollToFocused(menuRef);
-  const handleKeyDown = createKeyDownHandler(dispatch, state, scrollToFocused);
+  useScrollToFocused(menuRef);
+  const handleKeyDown = createKeyDownHandler(dispatch, state);
 
   return (
     <AccessibilityPropsProvider

--- a/src/SingleSelect.tsx
+++ b/src/SingleSelect.tsx
@@ -83,9 +83,9 @@ export const SingleSelect = <
 
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
   useScrollCaptor(menuRef);
-  const scrollToFocused = useScrollToFocused(menuRef);
+  useScrollToFocused(menuRef);
   const placementStyles = useMenuPlacementStyles(menuRef);
-  const handleKeyDown = createKeyDownHandler(dispatch, state, scrollToFocused);
+  const handleKeyDown = createKeyDownHandler(dispatch, state);
 
   return (
     <AccessibilityPropsProvider


### PR DESCRIPTION
At the moment, `useScrollToFocused` returns a function to be called prior to state updates that would move the focused option outside the bounds of its parent element. I've never been particularly fond of this solution but it does solve two problems that occur without this explicit trigger:
1. focusing the top/bottom options with the mouse tends to cause a loop where `scrollIntoView` is called for the following, out-of-sight option, and then the next, and the next etc until the scrollbar hits the limits. There's something like a single-pixel boundary at the edge of the element that receives `scrollIntoView` where mouse events can still reach the following option
2. scrolling through options with the keyboard while the cursor is over an option causes the focus to jump back up the list to the cursor's position

This PR provides an alternate solution for both of these issues:
1. rather than opting in to the scroll behavior, we opt _out_ by keeping track of the last element that received focus, and skipping the scroll if that element receives `aria-selected`. The "scroll on update" callback is no longer required, which cleans up the default key handler. It catches events that currently focus an out-of-sight option without scrolling to it, like typing while a long list of options is scrolled down
2. the `Option` component only dispatches a focus action on `mousemove` now, as opposed to `mouseover`. This event isn't fired if the mouse enters an element by any means other than human interaction with the mouse

Caveats:
- smooth scrolling is disabled. There's some issue in Chrome where `scrollToFocus` fails under certain circumstances when it's enabled, and it doesn't work in Safari at all, so we trade off that pretty animation for more predictable behavior
- need to make sure it's OK that we ignore `mouseover` events on `Option`. Might be scenarios where it's preferable to `mousemove`